### PR TITLE
Handle knockouts promotion when fewer than four teams

### DIFF
--- a/comp/knockout.html
+++ b/comp/knockout.html
@@ -43,7 +43,7 @@ See the <a href="/comp/schedule">match schedule</a> for information about the cu
                     <li data-ng-repeat="tla in game.teams track by $index">
 {% if site.teams_url %}
                         <a data-ng-href="{{ site.teams_url }}[[ tla ]]"
-                           data-ng-class="{promote: !isFinal && (game.ranking[tla] == 1 || game.ranking[tla] == 2)}"
+                           data-ng-class="{promote: !isFinal && (game.ranking[tla] - 1 &lt; num_promote)}"
                            data-ng-show="[[ tla != unknowable && tla != '-' ]]"
                            title="Find out more about team [[ tla|teamInfo:teams|teamName ]]">
                            [[ tla ]]
@@ -51,7 +51,7 @@ See the <a href="/comp/schedule">match schedule</a> for information about the cu
                         <span data-ng-show="[[ tla == unknowable || tla == '-' ]]">
 {% else %}
                         <span title="[[ tla|teamInfo:teams|teamName ]]"
-                              data-ng-class="{promote: !isFinal && (game.ranking[tla] == 1 || game.ranking[tla] == 2)}">
+                              data-ng-class="{promote: !isFinal && (game.ranking[tla] - 1 &lt; num_promote)}">
 {% endif %}
                            [[ tla ]]
                        </span>

--- a/js/controllers/KnockoutTree.js
+++ b/js/controllers/KnockoutTree.js
@@ -13,6 +13,11 @@ app.controller("KnockoutTree", function($scope, $log, Arenas, Corners, Current, 
     Corners.load(function(cornerId, corner) {
         $scope.corners[cornerId] = corner;
         num_corners = $scope.corners.length;
+        // Assume that the top half of teams in a knockout match go through.
+        // Ideally we'd probably do something like inferring the winners from
+        // the next round of matches and/or have it explicitly provided by the
+        // API, however this works for now.
+        $scope.num_promote = Math.floor(num_corners / 2);
     });
 
     var update_knockout_started = function(now) {


### PR DESCRIPTION
This keeps the assumption that the top half of the teams go through, though that seems likely to remain the case given our current games of four or two zones.