### PR TITLE
Mark this CSS file as containing unicode

### DIFF
--- a/_sass/comp/common.scss
+++ b/_sass/comp/common.scss
@@ -1,3 +1,5 @@
+@charset "utf-8";
+
 @import "../brand/sass/srobo/variables/index";
 
 .main {


### PR DESCRIPTION
The root file already has this marker, so you'd hope that this wouldn't be needed, however we have seen build failures where developers don't have a suitable locale set, which this aims to avoid.

Note: this is a speculative change pending testing.