### PR TITLE
Annotate rookie teams in the league table

### DIFF
--- a/_sass/comp/league.scss
+++ b/_sass/comp/league.scss
@@ -13,4 +13,8 @@
       text-align: left;
     }
   }
+
+  .rookie-team {
+    font-style: italic;
+  }
 }

--- a/comp/league.html
+++ b/comp/league.html
@@ -29,6 +29,10 @@ The positions of the teams within the league are used to seed the <a href="/comp
 Details of the scores for each individual match are available on the <a href="/comp/points">points page</a>.
 </p>
 
+<p>
+Teams which have not competed before are shown <span class="rookie-team">in italics</span>.
+</p>
+
 <p data-ng-if="latest_scored_match != null">
 Up to date with scores from match [[ latest_scored_match ]].
 </p>
@@ -65,7 +69,7 @@ No scores have been recorded yet.
         </td>
         <td>[[ item.scores.league ]]</td>
         <td>[[ item.scores.game ]]</td>
-        <td>
+        <td data-ng-class="{'rookie-team':item.rookie}">
 {% if site.teams_url %}
             <a href="{{ site.teams_url }}/[[ item.tla ]]"
                title="Find out more about team [[ item.tla ]]"


### PR DESCRIPTION
Very open to other styling ideas, though probably don't want to draw too much attention to these when just scanning the table.
![image](https://user-images.githubusercontent.com/336212/224844924-ca1c8678-b870-4729-8ce2-32b93857f061.png)

As an alternative, here's bold:
![image](https://user-images.githubusercontent.com/336212/225110481-072edd26-4e46-4f1d-94ca-9c1c73c5900d.png)

