### PR TITLE
Support showing the 'game' start times

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,6 +24,12 @@ youtube_stream_link: https://www.youtube-nocookie.com/embed/p0KxrRNTGBs
 # Support branding the "zone" (what SRComp calls a "corner") in line with this year's game.
 game_term_zone: Corner
 
+# Whether to show match timings using the canonical "slot" timings or the
+# internal "game" timings. This does not affect the times at which a match is
+# shown as being the "current" match, only the times displayed in schedule
+# tables.
+match_timing_mode: game
+
 links:
   donate: //link.justgiving.com/v1/charity/donate/charityId/3118662?tipScheme=TipJar2.1&isRecurring=false&amount=10.00&reference=givingcheckout_tj21
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -49,6 +49,7 @@
 
 	<script type="text/javascript">
 		var API_ROOT = "{{ site.api_root }}";
+		var MATCH_TIMING_MODE = "{{ site.match_timing_mode }}";
 	</script>
 
 	<script type="text/javascript" src="{{ site.baseurl }}/js/polyfill.js"></script>

--- a/comp/team.html
+++ b/comp/team.html
@@ -48,9 +48,9 @@ Teams who arrive late may forfeit the match.
 
 <p data-ng-if="next_game">
     <strong>Next: [[ next_game.display_name ]]</strong>
-    <!-- Time to the start of the slot; shown far in advance -->
-    <span data-ng-if="time_to_next_slot && long_before_staging">
-        (starts in [[ time_to_next_slot ]])
+    <!-- Time to the advertised start of the match; shown far in advance -->
+    <span data-ng-if="time_to_next_advertised && long_before_staging">
+        (starts in [[ time_to_next_advertised ]])
     </span>
     <!-- Time to the start of the actual game; shown after staging has closed -->
     <span data-ng-if="time_to_next_game && !staging_closes">

--- a/comp/team.html
+++ b/comp/team.html
@@ -48,11 +48,11 @@ Teams who arrive late may forfeit the match.
 
 <p data-ng-if="next_game">
     <strong>Next: [[ next_game.display_name ]]</strong>
-    <!-- Time to the start of the slot -->
+    <!-- Time to the start of the slot; shown far in advance -->
     <span data-ng-if="time_to_next_slot && long_before_staging">
         (starts in [[ time_to_next_slot ]])
     </span>
-    <!-- Time to the start of the actual game -->
+    <!-- Time to the start of the actual game; shown after staging has closed -->
     <span data-ng-if="time_to_next_game && !staging_closes">
         (starts in [[ time_to_next_game ]])
     </span>

--- a/js/controllers/TeamInformation.js
+++ b/js/controllers/TeamInformation.js
@@ -76,6 +76,9 @@ app.controller("TeamInformation", function($scope, $interval, $localStorage, gam
         // Set the time to the next match
         $scope.next_game = get_next_game($scope.games);
         if ($scope.next_game != null) {
+            // Capture timings for the next game. Values are template-ready
+            // strings or null if the time is in the past.
+
             $scope.time_to_next_game = describe_time_until($scope.next_game.game_time);
             $scope.time_to_next_slot = describe_time_until($scope.next_game.time);
 

--- a/js/controllers/TeamInformation.js
+++ b/js/controllers/TeamInformation.js
@@ -57,7 +57,7 @@ app.controller("TeamInformation", function($scope, $interval, $localStorage, gam
         var now = Current.timeFromOffset($scope.time_offset);
         for (var i=0; i<scheduled_games.length; i++) {
             var game = scheduled_games[i];
-            game.time = new Date(game.times.slot.start);
+            game.time = match_timings(game, MATCH_TIMING_MODE).start;
 
             if (now < game.time &&
                 (next_game == null || game.time < next_game.time)) {
@@ -80,7 +80,7 @@ app.controller("TeamInformation", function($scope, $interval, $localStorage, gam
             // strings or null if the time is in the past.
 
             $scope.time_to_next_game = describe_time_until($scope.next_game.game_time);
-            $scope.time_to_next_slot = describe_time_until($scope.next_game.time);
+            $scope.time_to_next_advertised = describe_time_until($scope.next_game.time);
 
             var staging_opens = $scope.next_game.staging_times['opens'];
             var opens_seconds = seconds_until(staging_opens);

--- a/tests/js/competition-utils.spec.js
+++ b/tests/js/competition-utils.spec.js
@@ -1,4 +1,6 @@
 
+var MATCH_TIMING_MODE = ''; // slot
+
 var utils = require('../../js/competition-utils.js');
 
 describe("The decision about whether we show an arena title", function() {
@@ -62,6 +64,10 @@ describe("The match schedule converter sorter helpers", function() {
 					'slot': {
 						'end': 'Sat, 15 Mar 2014 00:05:00 GMT',
 						'start': 'Sat, 15 Mar 2014 00:00:00 GMT'
+					},
+					'game': {
+						'end': 'Sat, 15 Mar 2014 00:04:00 GMT',
+						'start': 'Sat, 15 Mar 2014 00:01:00 GMT'
 					}
 				},
 				'num': 0,
@@ -73,6 +79,10 @@ describe("The match schedule converter sorter helpers", function() {
 					'slot': {
 						'end': 'Sat, 15 Mar 2014 00:05:00 GMT',
 						'start': 'Sat, 15 Mar 2014 00:00:00 GMT'
+					},
+					'game': {
+						'end': 'Sat, 15 Mar 2014 00:04:00 GMT',
+						'start': 'Sat, 15 Mar 2014 00:01:00 GMT'
 					}
 				},
 				'num': 0,
@@ -88,6 +98,20 @@ describe("The match schedule converter sorter helpers", function() {
 	});
 	it("should flatten and simplify match descriptions", function() {
 		var match = utils.match_converter(4, input, arenas);
+		expect(match).toEqual(expected);
+	});
+	it("should use slot timings when implicitly asked", function() {
+		var match = utils.match_converter(4, input, arenas, {unrelated: null});
+		expect(match).toEqual(expected);
+	});
+	it("should use slot timings when explicitly asked", function() {
+		var match = utils.match_converter(4, input, arenas, {match_timing_mode: 'slot'});
+		expect(match).toEqual(expected);
+	});
+	it("should use game timings when asked", function() {
+		var match = utils.match_converter(4, input, arenas, {match_timing_mode: 'game'});
+    expected.time = new Date('2014-03-15 00:01:00');
+    expected.end_time = new Date('2014-03-15 00:04:00');
 		expect(match).toEqual(expected);
 	});
 	it("should flatten and simplify the collection of matches", function() {


### PR DESCRIPTION
For SR2025 we want to show on the website the time at which the game starts rather than the slot timings. This adds and activates support for doing this, while keeping the previous support for compatibility with other compstates.