### PR TITLE
Update the livestream url for the first day of the competition

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@ api_root: https://studentrobotics.org/comp-api
 challenges_link: https://studentrobotics.org/docs/resources/2025/challenges.html
 virtual_competition_link: https://studentrobotics.org/events/sr2025/virtual-competition/
 competition_link: https://studentrobotics.org/events/sr2025/virtual-competition/
-youtube_stream_link: https://www.youtube-nocookie.com/embed/p0KxrRNTGBs
+youtube_stream_link: https://www.youtube-nocookie.com/embed/iJwuYluRUjE
 venue_layout_link: https://studentrobotics.org/resources/sr2025/venue-map.pdf
 
 # Support branding the "zone" (what SRComp calls a "corner") in line with this year's game.


### PR DESCRIPTION
Taken from the [event page](https://studentrobotics.org/events/sr2025/competition/).